### PR TITLE
7 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # compiled output
 /node_modules
 .env
+/coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,0 @@
-export default {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,9 @@
+import type {Config} from 'jest';
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testTimeout: 10000
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "app": "nodemon src/app.ts",
+    "app": "nodemon src/index.ts",
     "lint": "eslint . --ext .ts",
     "typeorm": "typeorm-ts-node-esm -d ./src/data-access/dbConfig.ts",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.16",
     "@types/express-winston": "^4.0.0",
+    "@types/jest": "^29.4.0",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/morgan": "^1.9.4",
     "@types/node": "^18.11.18",
+    "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^5.47.1",
     "@typescript-eslint/parser": "^5.47.1",
     "eslint": "^8.30.0",
@@ -43,6 +45,7 @@
     "sequelize": "^6.28.0",
     "sqlite3": "^5.1.4",
     "supertest": "^6.3.3",
+    "ts-jest": "^29.0.5",
     "typeorm": "^0.3.11",
     "winston": "^3.8.2"
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "app": "nodemon src/app.ts",
     "lint": "eslint . --ext .ts",
-    "typeorm": "typeorm-ts-node-esm -d ./src/data-access/dbConfig.ts"
+    "typeorm": "typeorm-ts-node-esm -d ./src/data-access/dbConfig.ts",
+    "test": "jest"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",
@@ -33,6 +34,7 @@
     "express-async-errors": "^3.1.1",
     "express-joi-validation": "^5.0.1",
     "express-winston": "^4.2.0",
+    "jest": "^29.4.2",
     "jsonwebtoken": "^9.0.0",
     "morgan": "^1.10.0",
     "pg": "^8.8.0",
@@ -40,6 +42,7 @@
     "reflect-metadata": "^0.1.13",
     "sequelize": "^6.28.0",
     "sqlite3": "^5.1.4",
+    "supertest": "^6.3.3",
     "typeorm": "^0.3.11",
     "winston": "^3.8.2"
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,33 +1,5 @@
-import express from 'express';
-import "reflect-metadata";
-import cors from 'cors';
-import * as dotenv from 'dotenv'
-import user from './routers/user';
-import group from './routers/group';
-import { errorHandlerMiddleware } from './middlewares/errorHandlerMiddleware';
-import {processListener} from './process'
-import { loggerMiddleware } from './middlewares/loggerMiddleware';
-import { logger } from './logger/winstonLogger';
-import { checkTokenMiddleware } from './middlewares/checkTokenMiddleware';
+import createApplication from "./createApp";
+import GroupService from "./services/groupService";
+import UserService from "./services/userService";
 
-const app = express();
-dotenv.config()
-
-// Enable Cross Origin Resource Sharing to all origins by default
-app.use(cors());
-// Transforms the raw string of req.body into json
-app.use(express.json());
-//load common middlewares
-app.use(loggerMiddleware, checkTokenMiddleware);
-// Load API routes
-app.use(user, group);
-
-//load error handler
-app.use(errorHandlerMiddleware);
-
-app.listen(process.env.PORT, () => {
-  logger.info(`App listening at http://localhost:${process.env.PORT}`)
-  });
-
-//handle unhandled errors  
-processListener();
+createApplication(new UserService(), new GroupService());

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,0 @@
-import createApplication from "./createApp";
-import GroupService from "./services/groupService";
-import UserService from "./services/userService";
-
-createApplication(new UserService(), new GroupService());

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -1,0 +1,40 @@
+import express from 'express';
+import 'reflect-metadata';
+import cors from 'cors';
+import * as dotenv from 'dotenv';
+import { errorHandlerMiddleware } from './middlewares/errorHandlerMiddleware';
+import { processListener } from './process';
+import { loggerMiddleware } from './middlewares/loggerMiddleware';
+import { logger } from './logger/winstonLogger';
+import { checkTokenMiddleware } from './middlewares/checkTokenMiddleware';
+import createGroupRouter from './routers/group';
+import createUserRouter from './routers/user';
+import type GroupService from './services/groupService';
+import type UserService from './services/userService';
+
+export default function createApplication(userService:UserService, groupService:GroupService) {
+  const app = express();
+  dotenv.config();
+
+  // Enable Cross Origin Resource Sharing to all origins by default
+  app.use(cors());
+  // Transforms the raw string of req.body into json
+  app.use(express.json());
+  //load common middlewares
+  app.use(loggerMiddleware, checkTokenMiddleware);
+  // Load API routes
+  app.use(createUserRouter(userService), createGroupRouter(groupService));
+
+  //load error handler
+  app.use(errorHandlerMiddleware);
+
+  const server= app.listen(process.env.PORT, () => {
+    logger.info(`App listening at http://localhost:${process.env.PORT}`);
+  });
+
+  //handle unhandled errors
+  processListener();
+
+  return {app, server}
+}
+

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -3,9 +3,7 @@ import 'reflect-metadata';
 import cors from 'cors';
 import * as dotenv from 'dotenv';
 import { errorHandlerMiddleware } from './middlewares/errorHandlerMiddleware';
-import { processListener } from './process';
 import { loggerMiddleware } from './middlewares/loggerMiddleware';
-import { logger } from './logger/winstonLogger';
 import { checkTokenMiddleware } from './middlewares/checkTokenMiddleware';
 import createGroupRouter from './routers/group';
 import createUserRouter from './routers/user';
@@ -28,13 +26,6 @@ export default function createApplication(userService:UserService, groupService:
   //load error handler
   app.use(errorHandlerMiddleware);
 
-  const server= app.listen(process.env.PORT, () => {
-    logger.info(`App listening at http://localhost:${process.env.PORT}`);
-  });
-
-  //handle unhandled errors
-  processListener();
-
-  return {app, server}
+  return app
 }
 

--- a/src/data-access/dbConfig.ts
+++ b/src/data-access/dbConfig.ts
@@ -1,5 +1,7 @@
 import * as dotenv from 'dotenv';
 import { DataSource } from 'typeorm';
+import { DBInitializationError } from '../customErrors';
+import { logger } from '../logger/winstonLogger';
 import { myMigration1673944710450 } from '../migrations/1673944710450-my-migration';
 import { Group, User} from '../models/typeORMModels';
 dotenv.config();
@@ -22,6 +24,14 @@ const dataSource = new DataSource({
   subscribers: [],
   migrations: [myMigration1673944710450],
 });
+
+dataSource.initialize()
+  .then(() => {
+    logger.info('Data base initialized');
+  })
+  .catch(() => {
+    throw new DBInitializationError('initialize faled');
+  });
 
 // npm run typeorm -- migration:generate ./src/migrations/my-migration
 // npm run typeorm -- migration:run

--- a/src/data-access/dbConfig.ts
+++ b/src/data-access/dbConfig.ts
@@ -30,7 +30,7 @@ dataSource.initialize()
     logger.info('Data base initialized');
   })
   .catch(() => {
-    throw new DBInitializationError('initialize faled');
+    throw new DBInitializationError('initialization faled');
   });
 
 // npm run typeorm -- migration:generate ./src/migrations/my-migration

--- a/src/data-access/typeORMDataAccess.ts
+++ b/src/data-access/typeORMDataAccess.ts
@@ -1,20 +1,10 @@
 import {
-  DBInitializationError,
   FindGroupError,
   FindUserError,
 } from '../customErrors';
-import { logger } from '../logger/winstonLogger';
 import { Group, User } from '../models/typeORMModels';
 import { GroupUpdates, UserUpdates } from '../types';
 import AppDataSource from './dbConfig';
-
-AppDataSource.initialize()
-  .then(() => {
-    logger.info('Data base initialized');
-  })
-  .catch((e) => {
-    throw new DBInitializationError('initialize faled');
-  });
 
 export async function createUser(newUser: User) {
   const result = await AppDataSource.transaction(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,14 @@
+import createApplication from './createApp';
+import { logger } from './logger/winstonLogger';
+import { processListener } from './process';
+import GroupService from './services/groupService';
+import UserService from './services/userService';
+
+const application = createApplication(new UserService(), new GroupService());
+
+application.listen(process.env.PORT, () => {
+  logger.info(`App listening at http://localhost:${process.env.PORT}`);
+});
+
+//handle unhandled errors
+processListener();

--- a/src/middlewares/checkTokenMiddleware.ts
+++ b/src/middlewares/checkTokenMiddleware.ts
@@ -7,7 +7,7 @@ export const checkTokenMiddleware = function (
   res: Response,
   next: NextFunction
 ) {
-  console.log(req.path)
+
   if(req.path === '/user/login') return next()
 
   const token = typeof req.headers['jwt-access-token'] === 'string' ? req.headers['jwt-access-token'] : undefined ;

--- a/src/routers/group.ts
+++ b/src/routers/group.ts
@@ -1,5 +1,5 @@
 import express, { NextFunction, Request, Response } from 'express';
-import { GroupService } from '../services/groupService';
+import GroupService from '../services/groupService';
 import {
   groupBodyValidatorOnCreate,
   groupBodyValidatorOnUpdate,
@@ -16,118 +16,119 @@ import {
 } from '../validation/types';
 import { methodLoggerMiddleware } from '../middlewares/methodLoggerMiddleware';
 
-const group = express.Router();
-const groupService = new GroupService();
+export default function createGroupRouter(groupService: GroupService) {
+  const group = express.Router();
 
-group.post(
-  '/group',
-  groupBodyValidatorOnCreate,
-  methodLoggerMiddleware,
-  async (
-    req: ValidatedRequest<CreateGroupBodySchema>,
-    res: Response,
-    next: NextFunction
-  ) => {
-    try {
-      const group: Group = { ...req.body };
-      const result = await groupService.createGroup(group);
-      res.status(200).json({ createdGroup: result });
-    } catch (e) {
-      next(e);
+  group.post(
+    '/group',
+    groupBodyValidatorOnCreate,
+    methodLoggerMiddleware,
+    async (
+      req: ValidatedRequest<CreateGroupBodySchema>,
+      res: Response,
+      next: NextFunction
+    ) => {
+      try {
+        const group: Group = { ...req.body };
+        const result = await groupService.createGroup(group);
+        res.status(200).json({ createdGroup: result });
+      } catch (e) {
+        next(e);
+      }
     }
-  }
-);
+  );
 
-group.get(
-  '/group/:id',
-  paramsIdValidator,
-  methodLoggerMiddleware,
-  async (
-    req: ValidatedRequest<ParamsIDSchema>,
-    res: Response,
-    next: NextFunction
-  ) => {
-    try {
-      const { id } = req.params;
-      const result = await groupService.getGroupById(id);
-      res.status(200).json({ group: result });
-    } catch (e) {
-      next(e);
+  group.get(
+    '/group/:id',
+    paramsIdValidator,
+    methodLoggerMiddleware,
+    async (
+      req: ValidatedRequest<ParamsIDSchema>,
+      res: Response,
+      next: NextFunction
+    ) => {
+      try {
+        const { id } = req.params;
+        const result = await groupService.getGroupById(id);
+        res.status(200).json({ group: result })
+      } catch (e) {
+        next(e);
+      }
     }
-  }
-);
+  );
 
-group.get(
-  '/groups',
-  methodLoggerMiddleware,
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const result = await groupService.getGroups();
-      res.status(200).json({ groups: result });
-    } catch (e) {
-      next(e);
+  group.get(
+    '/groups',
+    methodLoggerMiddleware,
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const result = await groupService.getGroups();
+        res.status(200).json({ groups: result });
+      } catch (e) {
+        next(e);
+      }
     }
-  }
-);
+  );
 
-group.put(
-  '/group/:id',
-  groupBodyValidatorOnUpdate,
-  paramsIdValidator,
-  methodLoggerMiddleware,
-  async (
-    req: ValidatedRequest<ParamsIDSchema & UpdateUserBodySchema>,
-    res: Response,
-    next: NextFunction
-  ) => {
-    try {
-      const { id } = req.params;
-      const result = await groupService.updateGroup(id, req.body);
-      res.status(200).json({ updatedGroup: result });
-    } catch (e) {
-      next(e);
+  group.put(
+    '/group/:id',
+    groupBodyValidatorOnUpdate,
+    paramsIdValidator,
+    methodLoggerMiddleware,
+    async (
+      req: ValidatedRequest<ParamsIDSchema & UpdateUserBodySchema>,
+      res: Response,
+      next: NextFunction
+    ) => {
+      try {
+        const { id } = req.params;
+        const result = await groupService.updateGroup(id, req.body);
+        res.status(200).json({ updatedGroup: result });
+      } catch (e) {
+        next(e);
+      }
     }
-  }
-);
+  );
 
-group.delete(
-  '/group/:id',
-  paramsIdValidator,
-  methodLoggerMiddleware,
-  async (
-    req: ValidatedRequest<ParamsIDSchema>,
-    res: Response,
-    next: NextFunction
-  ) => {
-    try {
-      const { id } = req.params;
-      groupService.deleteGroup(id);
-      res.status(200).json({ message: `group with id ${id} deleted` });
-    } catch (e) {
-      next(e);
+  group.delete(
+    '/group/:id',
+    paramsIdValidator,
+    methodLoggerMiddleware,
+    async (
+      req: ValidatedRequest<ParamsIDSchema>,
+      res: Response,
+      next: NextFunction
+    ) => {
+      try {
+        const { id } = req.params;
+        groupService.deleteGroup(id);
+        res.status(200).json({ message: `group with id ${id} deleted` });
+      } catch (e) {
+        next(e);
+      }
     }
-  }
-);
+  );
 
-group.post(
-  '/group/:id/addusers',
-  paramsIdValidator,
-  groupRelationsBodyValidator,
-  methodLoggerMiddleware,
-  async (
-    req: ValidatedRequest<ParamsIDSchema & CreateGroupRelationsBodySchema>,
-    res: Response,
-    next: NextFunction
-  ) => {
-    try {
-      const { id } = req.params;
-      const userIds: string[] = [...req.body.usersId];
-      const result = await groupService.addUsersToGroup(id, userIds);
-      res.status(200).json({ createdGroupRelations: result });
-    } catch (e) {
-      next(e);
+  group.post(
+    '/group/:id/addusers',
+    paramsIdValidator,
+    groupRelationsBodyValidator,
+    methodLoggerMiddleware,
+    async (
+      req: ValidatedRequest<ParamsIDSchema & CreateGroupRelationsBodySchema>,
+      res: Response,
+      next: NextFunction
+    ) => {
+      try {
+        const { id } = req.params;
+        const userIds: string[] = [...req.body.usersId];
+        const result = await groupService.addUsersToGroup(id, userIds);
+        res.status(200).json({ createdGroupRelations: result });
+      } catch (e) {
+        next(e);
+      }
     }
-  }
-);
+  );
 
-export default group;
+  return group;
+}

--- a/src/routers/user.ts
+++ b/src/routers/user.ts
@@ -1,5 +1,5 @@
 import express, { NextFunction, Response } from 'express';
-import { UserService } from '../services/userService';
+import UserService from '../services/userService';
 import {
   userBodyValidatorOnCreate,
   userBodyValidatorOnUpdate,
@@ -20,142 +20,137 @@ import { methodLoggerMiddleware } from '../middlewares/methodLoggerMiddleware';
 import * as jwt from 'jsonwebtoken';
 import { LoginError } from '../customErrors';
 
-const user = express.Router();
-const userService = new UserService();
+export default function createUserRouter(userService: UserService) {
+  const user = express.Router();
 
-user.post(
-  '/user',
-  userBodyValidatorOnCreate,
-  methodLoggerMiddleware,
-  async (
-    req: ValidatedRequest<CreateUserBodySchema>,
-    res: Response,
-    next: NextFunction
-  ) => {
-    try {
-      const user: User = { ...req.body };
-      const result = await userService.createUser(user);
-      res.status(200).json({ createdUser: result });
-    } catch (e) {
-      // pass error to errorHandler
-      next(e);
-    }
-  }
-);
-
-user.get(
-  '/user/:id',
-  paramsIdValidator,
-  methodLoggerMiddleware,
-  async (
-    req: ValidatedRequest<ParamsIDSchema>,
-    res: Response,
-    next: NextFunction
-  ) => {
-    try {
-      const { id } = req.params;
-      const result = await userService.getUserById(id);
-      result
-        ? res.status(200).json({ user: result })
-        : res.status(404).json({ message: `no users with id ${id}` });
-    } catch (e) {
-      next(e);
-    }
-  }
-);
-
-user.put(
-  '/user/:id',
-  userBodyValidatorOnUpdate,
-  paramsIdValidator,
-  methodLoggerMiddleware,
-  async (
-    req: ValidatedRequest<ParamsIDSchema & UpdateUserBodySchema>,
-    res: Response,
-    next: NextFunction
-  ) => {
-    try {
-      const { id } = req.params;
-      const result = await userService.updateUser(id, req.body);
-      result
-        ? res.status(200).json({ updatedUser: result })
-        : res.status(404).json({ message: `no users with id ${id}` });
-    } catch (e) {
-      next(e);
-    }
-  }
-);
-
-user.delete(
-  '/user/:id',
-  paramsIdValidator,
-  methodLoggerMiddleware,
-  async (
-    req: ValidatedRequest<ParamsIDSchema>,
-    res: Response,
-    next: NextFunction
-  ) => {
-    try {
-      const { id } = req.params;
-      const result = await userService.deleteUser(id);
-      result
-        ? res
-            .status(200)
-            .json({ message: `user with id ${id} marked as deleted` })
-        : res.status(404).json({ message: `no users with id ${id}` });
-    } catch (e) {
-      next(e);
-    }
-  }
-);
-
-user.get(
-  '/users',
-  userQuerySubstringLimitValidator,
-  methodLoggerMiddleware,
-  async (
-    req: ValidatedRequest<QuerySubstringLimitSchema>,
-    res: Response,
-    next: NextFunction
-  ) => {
-    try {
-      const { loginsubstring } = req.query;
-      const { limit } = req.query;
-
-      const result = await userService.getUsers(loginsubstring, limit);
-      res.status(200).json({ users: result });
-    } catch (e) {
-      next(e);
-    }
-  }
-);
-
-user.post(
-  '/user/login',
-  userBodyCredentialsValidator,
-  async (
-    req: ValidatedRequest<GetUserByCredentialsBodySchema>,
-    res: Response,
-    next: NextFunction
-  ) => {
-
-    try {
-      const { login, password } = req.body;
-
-      const result = await userService.getUserByCredentials(login, password);
-
-      if (result instanceof User) {
-        const payload = { sub: 'api access', userId: result.id };
-        const secret = process.env.SECRET as string;
-        const token = jwt.sign(payload, secret, { expiresIn: `${process.env.EXPIRESIN}ms` });
-        res.status(200).json({ token });
-      } else {
-        throw new LoginError('Bad Username/Passsword combination')
+  user.post(
+    '/user',
+    userBodyValidatorOnCreate,
+    methodLoggerMiddleware,
+    async (
+      req: ValidatedRequest<CreateUserBodySchema>,
+      res: Response,
+      next: NextFunction
+    ) => {
+      try {
+        const user: User = { ...req.body };
+        const result = await userService.createUser(user);
+        res.status(200).json({ createdUser: result });
+      } catch (e) {
+        // pass error to errorHandler
+        next(e);
       }
-    } catch (e) {
-      next(e);
     }
-  }
-);
+  );
 
-export default user;
+  user.get(
+    '/user/:id',
+    paramsIdValidator,
+    methodLoggerMiddleware,
+    async (
+      req: ValidatedRequest<ParamsIDSchema>,
+      res: Response,
+      next: NextFunction
+    ) => {
+      try {
+        const { id } = req.params;
+        const result = await userService.getUserById(id);
+        res.status(200).json({ user: result });
+      } catch (e) {
+        next(e);
+      }
+    }
+  );
+
+  user.put(
+    '/user/:id',
+    userBodyValidatorOnUpdate,
+    paramsIdValidator,
+    methodLoggerMiddleware,
+    async (
+      req: ValidatedRequest<ParamsIDSchema & UpdateUserBodySchema>,
+      res: Response,
+      next: NextFunction
+    ) => {
+      try {
+        const { id } = req.params;
+        const result = await userService.updateUser(id, req.body);
+        res.status(200).json({ updatedUser: result });
+      } catch (e) {
+        next(e);
+      }
+    }
+  );
+
+  user.delete(
+    '/user/:id',
+    paramsIdValidator,
+    methodLoggerMiddleware,
+    async (
+      req: ValidatedRequest<ParamsIDSchema>,
+      res: Response,
+      next: NextFunction
+    ) => {
+      try {
+        const { id } = req.params;
+        await userService.deleteUser(id);
+        res
+          .status(200)
+          .json({ message: `user with id ${id} marked as deleted` });
+      } catch (e) {
+        next(e);
+      }
+    }
+  );
+
+  user.get(
+    '/users',
+    userQuerySubstringLimitValidator,
+    methodLoggerMiddleware,
+    async (
+      req: ValidatedRequest<QuerySubstringLimitSchema>,
+      res: Response,
+      next: NextFunction
+    ) => {
+      try {
+        const { loginsubstring } = req.query;
+        const { limit } = req.query;
+
+        const result = await userService.getUsers(loginsubstring, limit);
+        res.status(200).json({ users: result });
+      } catch (e) {
+        next(e);
+      }
+    }
+  );
+
+  user.post(
+    '/user/login',
+    userBodyCredentialsValidator,
+    async (
+      req: ValidatedRequest<GetUserByCredentialsBodySchema>,
+      res: Response,
+      next: NextFunction
+    ) => {
+      try {
+        const { login, password } = req.body;
+        const result = await userService.getUserByCredentials(login, password);
+
+        if (result instanceof User) {
+          const payload = { sub: 'api access', userId: result.id };
+          const secret = process.env.SECRET as string;
+          const token = jwt.sign(payload, secret, {
+            expiresIn: `${process.env.EXPIRESIN}ms`,
+          });
+          res.status(200).json({ token });
+        } else {
+          throw new LoginError('Bad Username/Password combination');
+        }
+      } catch (e) {
+        next(e);
+      }
+    }
+  );
+
+  return user;
+}

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -2,7 +2,7 @@ import * as Repository from '../data-access/typeORMDataAccess';
 import { Group } from '../models/typeORMModels';
 import { GroupUpdates } from '../types';
 
-export class GroupService {
+export default class GroupService {
   public async createGroup(group: Group) {
     const result = await Repository.createGroup(group);
     return result;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -2,7 +2,7 @@ import * as Repository from '../data-access/typeORMDataAccess';
 import { User } from '../models/typeORMModels';
 import { UserUpdates } from '../types';
 
-export class UserService {
+export default class UserService {
   public async createUser(user: User) {
     return await Repository.createUser(user);
   }

--- a/tests/controller.test.ts
+++ b/tests/controller.test.ts
@@ -83,15 +83,12 @@ async function getValidJWT() {
   return response.body.token;
 }
 
-const { app: application, server } = createApplication(
+const application = createApplication(
   mockUserService,
   mockGroupService
 );
 
 describe('CONTROLLER: ', () => {
-  afterAll(() => {
-    server.close();
-  });
 
   describe('User Controller: ', () => {
     describe('POST /user/login', () => {

--- a/tests/controller.test.ts
+++ b/tests/controller.test.ts
@@ -1,0 +1,860 @@
+import request from 'supertest';
+import createApplication from '../src/createApp';
+import { FindGroupError } from '../src/customErrors';
+import { User } from '../src/models/typeORMModels';
+
+const mockUserService = {
+  createUser: jest.fn(),
+  getUserById: jest.fn(),
+  updateUser: jest.fn(),
+  deleteUser: jest.fn(),
+  getUsers: jest.fn(),
+  getUserByCredentials: jest.fn(),
+};
+
+const mockGroupService = {
+  createGroup: jest.fn(),
+  getGroupById: jest.fn(),
+  updateGroup: jest.fn(),
+  deleteGroup: jest.fn(),
+  getGroups: jest.fn(),
+  addUsersToGroup: jest.fn(),
+};
+
+const validCredentials = {
+  login: 'log123',
+  password: 'password1234',
+};
+
+const validUserData = {
+  ...validCredentials,
+  age: 30,
+  is_deleted: false,
+};
+
+const validGroupName = 'grpup1';
+const notValidGroupName = 'g';
+const validGroupId = '44e042a2-2acd-466f-bdfc-ec1e7a671dsd';
+const notValidGroupId = 'not valid ID';
+const validGroupPermissions = [
+  'READ',
+  'WRITE',
+  'DELETE',
+  'SHARE',
+  'UPLOAD_FILES',
+];
+const notValidGroupPermissions = [
+  'READ1',
+  'WRITE',
+  'DELETE',
+  'SHARE',
+  'UPLOAD_FILES',
+];
+const notValidJWT = 'not valid string';
+const validUserId = '44e042a2-2acd-466f-bdfc-ec1e7a671dsd';
+const validUserIds = [
+  '44e042a2-2acd-466f-bdfc-ec1e7a671dsd',
+  '54e042a2-2acd-466f-bdfc-ec1e7a671dsd',
+];
+const notValidUserIds = [
+  '44e042a2-2acd-466f-bdfc-ec1e7a671d',
+  '54e042a2-2acd-466f-bdfc-ec1e7a671d',
+];
+const notValidLogin = 'a';
+const notValidPassword = '1';
+const notValidUserId = 'not valid ID';
+const validSubstring = 'log';
+const notValidSubstring = 'logaaaaaaaaaaa';
+const validLimit = 3;
+const notValidLimit = 'a';
+
+const validGroupData = {
+  name: validGroupName,
+  permissions: validGroupPermissions,
+};
+
+async function getValidJWT() {
+  const credentials = validCredentials;
+  const user = new User();
+  mockUserService.getUserByCredentials.mockReturnValue(user);
+  const response = await request(application)
+    .post('/user/login')
+    .send(credentials);
+  return response.body.token;
+}
+
+const { app: application, server } = createApplication(
+  mockUserService,
+  mockGroupService
+);
+
+describe('CONTROLLER: ', () => {
+  afterAll(() => {
+    server.close();
+  });
+
+  describe('User Controller: ', () => {
+    describe('POST /user/login', () => {
+      beforeEach(() => {
+        mockUserService.getUserByCredentials.mockClear();
+      });
+      describe('when credentials passed validation', () => {
+        test('should trigger getUserByCredentials method with credentials', async () => {
+          const body = validCredentials;
+          await request(application).post('/user/login').send(body);
+          expect(mockUserService.getUserByCredentials).toBeCalledWith(
+            body.login,
+            body.password
+          );
+        });
+      });
+      describe('when credentials not valid', () => {
+        test('should respond with 400', async () => {
+          const body = {
+            ...validCredentials,
+            login: notValidLogin,
+          };
+          const response = await request(application)
+            .post('/user/login')
+            .send(body);
+          expect(mockUserService.getUserByCredentials).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when user not found by credentials', () => {
+        test('should respond with a 401 status code', async () => {
+          const body = validCredentials;
+          const user = {};
+          mockUserService.getUserByCredentials.mockReturnValueOnce(user);
+          const response = await request(application)
+            .post('/user/login')
+            .send(body);
+          expect(response.status).toBe(401);
+        });
+      });
+      describe('when user found by credentials', () => {
+        const body = validCredentials;
+        const user = new User();
+        mockUserService.getUserByCredentials.mockReturnValue(user);
+        test('should respond with a 200 status code', async () => {
+          const response = await request(application)
+            .post('/user/login')
+            .send(body);
+          expect(response.status).toBe(200);
+        });
+        test('should respond with a token', async () => {
+          const response = await request(application)
+            .post('/user/login')
+            .send(body);
+          expect(response.body.token.length).toBeGreaterThan(83);
+          expect(typeof response.body.token).toBe('string');
+        });
+      });
+    });
+
+    describe('POST /user (create user)', () => {
+      beforeEach(() => {
+        mockUserService.createUser.mockClear();
+      });
+      describe('when jwt not valid', () => {
+        test('should respond with 401', async () => {
+          const body = validUserData;
+          const response = await request(application)
+            .post('/user')
+            .set('jwt-access-token', notValidJWT)
+            .send(body);
+          expect(response.status).toBe(401);
+        });
+      });
+      describe('when no jwt', () => {
+        test('should respond with 403 ', async () => {
+          const body = validUserData;
+          const response = await request(application).post('/user').send(body);
+          expect(response.status).toBe(403);
+        });
+      });
+      describe('when user data valid', () => {
+        test('should trigger createUser method with user data', async () => {
+          const body = validUserData;
+          await request(application)
+            .post('/user')
+            .set('jwt-access-token', await getValidJWT())
+            .send(body);
+          expect(mockUserService.createUser).toBeCalledWith(body);
+        });
+        test('should respond with new user', async () => {
+          const body = validUserData;
+          mockUserService.createUser.mockReturnValueOnce(body);
+          const response = await request(application)
+            .post('/user')
+            .set('jwt-access-token', await getValidJWT())
+            .send(body);
+          expect(response.body.createdUser).toEqual(body);
+        });
+        test('should respond with 200', async () => {
+          const body = validUserData;
+          const response = await request(application)
+            .post('/user')
+            .set('jwt-access-token', await getValidJWT())
+            .send(body);
+          expect(response.status).toBe(200);
+        });
+      });
+      describe('when user data not valid', () => {
+        test('should respond with 400', async () => {
+          const body = {
+            ...validUserData,
+            login: notValidLogin,
+          };
+          const response = await request(application)
+            .post('/user')
+            .set('jwt-access-token', await getValidJWT())
+            .send(body);
+          expect(mockUserService.createUser).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+    });
+
+    describe('GET /user/:id (get user by id)', () => {
+      beforeEach(() => {
+        mockUserService.getUserById.mockClear();
+      });
+      describe('when jwt not valid', () => {
+        test('should respond with 401', async () => {
+          const response = await request(application)
+            .get(`/user/${validUserId}`)
+            .set('jwt-access-token', notValidJWT);
+          expect(response.status).toBe(401);
+        });
+      });
+      describe('when no jwt', () => {
+        test('should respond with 403 ', async () => {
+          const response = await request(application).get(
+            `/user/${validUserId}`
+          );
+          expect(response.status).toBe(403);
+        });
+      });
+      describe('when user id not valid', () => {
+        test('should respond with 400', async () => {
+          const response = await request(application)
+            .get(`/user/${notValidUserId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockUserService.getUserById).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when user not found', () => {
+        test('should respond with 404', async () => {
+          mockUserService.getUserById.mockImplementationOnce(() => {
+            throw new FindGroupError('no user');
+          });
+          const response = await request(application)
+            .get(`/user/${validUserId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockUserService.getUserById).toBeCalledWith(validUserId);
+          expect(response.status).toBe(404);
+        });
+      });
+      describe('when user found', () => {
+        test('should respond with 200', async () => {
+          mockUserService.getUserById.mockReturnValueOnce(validUserData);
+          const response = await request(application)
+            .get(`/user/${validUserId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockUserService.getUserById).toBeCalledWith(validUserId);
+          expect(response.status).toBe(200);
+        });
+        test('should respond with user data', async () => {
+          mockUserService.getUserById.mockReturnValueOnce(validUserData);
+          const response = await request(application)
+            .get(`/user/${validUserId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockUserService.getUserById).toBeCalledWith(validUserId);
+          expect(response.body.user).toEqual(validUserData);
+        });
+      });
+    });
+
+    describe('PUT /user/:id (update user)', () => {
+      beforeEach(() => {
+        mockUserService.updateUser.mockClear();
+      });
+      describe('when jwt not valid', () => {
+        test('should respond with 401', async () => {
+          const response = await request(application)
+            .put(`/user/${validUserId}`)
+            .set('jwt-access-token', notValidJWT)
+            .send(validUserData);
+          expect(response.status).toBe(401);
+        });
+      });
+      describe('when no jwt', () => {
+        test('should respond with 403 ', async () => {
+          const response = await request(application)
+            .put(`/user/${validUserId}`)
+            .send(validUserData);
+          expect(response.status).toBe(403);
+        });
+      });
+      describe('when user id not valid', () => {
+        test('should respond with 400', async () => {
+          const response = await request(application)
+            .put(`/user/${notValidUserId}`)
+            .set('jwt-access-token', await getValidJWT())
+            .send(validUserData);
+          expect(mockUserService.updateUser).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when user update data not valid', () => {
+        test('should respond with 400', async () => {
+          const response = await request(application)
+            .put(`/user/${validUserId}`)
+            .set('jwt-access-token', await getValidJWT())
+            .send({ ...validUserData, login: notValidLogin });
+          expect(mockUserService.updateUser).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when user not found', () => {
+        test('should respond with 404', async () => {
+          mockUserService.updateUser.mockImplementationOnce(() => {
+            throw new FindGroupError('no user');
+          });
+          const response = await request(application)
+            .put(`/user/${validUserId}`)
+            .set('jwt-access-token', await getValidJWT())
+            .send(validUserData);
+          expect(mockUserService.updateUser).toBeCalledWith(
+            validUserId,
+            validUserData
+          );
+          expect(response.status).toBe(404);
+        });
+      });
+      describe('when user found', () => {
+        test('should respond with 200', async () => {
+          mockUserService.updateUser.mockReturnValueOnce(validUserData);
+          const response = await request(application)
+            .put(`/user/${validUserId}`)
+            .set('jwt-access-token', await getValidJWT())
+            .send(validUserData);
+          expect(mockUserService.updateUser).toBeCalledWith(
+            validUserId,
+            validUserData
+          );
+          expect(response.status).toBe(200);
+        });
+        test('should respond with user data', async () => {
+          mockUserService.updateUser.mockReturnValueOnce(validUserData);
+          const response = await request(application)
+            .put(`/user/${validUserId}`)
+            .set('jwt-access-token', await getValidJWT())
+            .send(validUserData);
+          expect(mockUserService.updateUser).toBeCalledWith(
+            validUserId,
+            validUserData
+          );
+          expect(response.body.updatedUser).toEqual(validUserData);
+        });
+      });
+    });
+
+    describe('DELETE /user/:id (delete user)', () => {
+      beforeEach(() => {
+        mockUserService.deleteUser.mockClear();
+      });
+      describe('when jwt not valid', () => {
+        test('should respond with 401', async () => {
+          const response = await request(application)
+            .delete(`/user/${validUserId}`)
+            .set('jwt-access-token', notValidJWT);
+          expect(response.status).toBe(401);
+        });
+      });
+      describe('when no jwt', () => {
+        test('should respond with 403 ', async () => {
+          const response = await request(application).delete(
+            `/user/${validUserId}`
+          );
+          expect(response.status).toBe(403);
+        });
+      });
+      describe('when user id not valid', () => {
+        test('should respond with 400', async () => {
+          const response = await request(application)
+            .delete(`/user/${notValidUserId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockUserService.deleteUser).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when user not found', () => {
+        test('should respond with 404', async () => {
+          mockUserService.deleteUser.mockImplementationOnce(() => {
+            throw new FindGroupError('no user');
+          });
+          const response = await request(application)
+            .delete(`/user/${validUserId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockUserService.deleteUser).toBeCalledWith(validUserId);
+          expect(response.status).toBe(404);
+        });
+      });
+      describe('when user found', () => {
+        test('should respond with 200', async () => {
+          mockUserService.deleteUser.mockReturnValueOnce(validUserData);
+          const response = await request(application)
+            .delete(`/user/${validUserId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockUserService.deleteUser).toBeCalledWith(validUserId);
+          expect(response.status).toBe(200);
+        });
+        test('should respond with message', async () => {
+          mockUserService.deleteUser.mockReturnValueOnce(validUserData);
+          const response = await request(application)
+            .delete(`/user/${validUserId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockUserService.deleteUser).toBeCalledWith(validUserId);
+          expect(response.body.message).toEqual(
+            `user with id ${validUserId} marked as deleted`
+          );
+        });
+      });
+    });
+
+    describe('GET /users (get users)', () => {
+      beforeEach(() => {
+        mockUserService.getUsers.mockClear();
+      });
+      describe('when jwt not valid', () => {
+        test('should respond with 401', async () => {
+          const response = await request(application)
+            .get(`/users`)
+            .set('jwt-access-token', notValidJWT);
+          expect(response.status).toBe(401);
+        });
+      });
+      describe('when no jwt', () => {
+        test('should respond with 403 ', async () => {
+          const response = await request(application).get(`/users`);
+          expect(response.status).toBe(403);
+        });
+      });
+      describe('when limit param not valid', () => {
+        test('should respond with 400', async () => {
+          const response = await request(application)
+            .get(`/users?limit=${notValidLimit}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockUserService.getUsers).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when loginsubstring param not valid', () => {
+        test('should respond with 400', async () => {
+          const response = await request(application)
+            .get(`/users?loginsubstring=${notValidSubstring}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockUserService.getUsers).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when request valid', () => {
+        test('should respond with 200', async () => {
+          mockUserService.getUsers.mockReturnValueOnce(validUserData);
+          const response = await request(application)
+            .get(`/users?limit=${validLimit}&loginsubstring=${validSubstring}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockUserService.getUsers).toBeCalledWith(
+            validSubstring,
+            validLimit
+          );
+          expect(response.status).toBe(200);
+        });
+        test('should respond with data', async () => {
+          mockUserService.getUsers.mockReturnValueOnce(validUserData);
+          const response = await request(application)
+            .get(`/users?limit=${validLimit}&loginsubstring=${validSubstring}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockUserService.getUsers).toBeCalledWith(
+            validSubstring,
+            validLimit
+          );
+          expect(response.body.users).toEqual(validUserData);
+        });
+      });
+    });
+  });
+
+  describe('Group Controller: ', () => {
+    describe('POST /group (create group)', () => {
+      beforeEach(() => {
+        mockGroupService.createGroup.mockClear();
+      });
+      describe('when jwt not valid', () => {
+        test('should respond with 401', async () => {
+          const body = validGroupData;
+          const response = await request(application)
+            .post('/group')
+            .set('jwt-access-token', notValidJWT)
+            .send(body);
+          expect(response.status).toBe(401);
+        });
+      });
+      describe('when no jwt', () => {
+        test('should respond with 403 ', async () => {
+          const body = validGroupData;
+          const response = await request(application).post('/group').send(body);
+          expect(response.status).toBe(403);
+        });
+      });
+      describe('when group data valid', () => {
+        test('should trigger createGroup method with group data', async () => {
+          const body = validGroupData;
+          await request(application)
+            .post('/group')
+            .set('jwt-access-token', await getValidJWT())
+            .send(body);
+          expect(mockGroupService.createGroup).toBeCalledWith(body);
+        });
+        test('should respond with new group', async () => {
+          const body = validGroupData;
+          mockGroupService.createGroup.mockReturnValueOnce(body);
+          const response = await request(application)
+            .post('/group')
+            .set('jwt-access-token', await getValidJWT())
+            .send(body);
+          expect(response.body.createdGroup).toEqual(body);
+        });
+        test('should respond with 200', async () => {
+          const body = validGroupData;
+          const response = await request(application)
+            .post('/group')
+            .set('jwt-access-token', await getValidJWT())
+            .send(body);
+          expect(response.status).toBe(200);
+        });
+      });
+      describe('when group data not valid', () => {
+        test('should respond with 400', async () => {
+          const body = {
+            ...validGroupData,
+            name: notValidGroupName,
+          };
+          const response = await request(application)
+            .post('/group')
+            .set('jwt-access-token', await getValidJWT())
+            .send(body);
+          expect(mockGroupService.createGroup).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+    });
+
+    describe('GET /group/:id (get group by id)', () => {
+      beforeEach(() => {
+        mockGroupService.getGroupById.mockClear();
+      });
+      describe('when jwt not valid', () => {
+        test('should respond with 401', async () => {
+          const response = await request(application)
+            .get(`/group/${validGroupId}`)
+            .set('jwt-access-token', notValidJWT);
+          expect(response.status).toBe(401);
+        });
+      });
+      describe('when no jwt', () => {
+        test('should respond with 403 ', async () => {
+          const response = await request(application).get(
+            `/group/${validGroupId}`
+          );
+          expect(response.status).toBe(403);
+        });
+      });
+      describe('when group id not valid', () => {
+        test('should respond with 400', async () => {
+          const response = await request(application)
+            .get(`/group/${notValidGroupId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockGroupService.getGroupById).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when group not found', () => {
+        test('should respond with 404', async () => {
+          mockGroupService.getGroupById.mockImplementationOnce(() => {
+            throw new FindGroupError('no group');
+          });
+          const response = await request(application)
+            .get(`/group/${validGroupId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockGroupService.getGroupById).toBeCalledWith(validGroupId);
+          expect(response.status).toBe(404);
+        });
+      });
+      describe('when group found', () => {
+        test('should respond with 200', async () => {
+          mockGroupService.getGroupById.mockReturnValueOnce(validGroupData);
+          const response = await request(application)
+            .get(`/group/${validGroupId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockGroupService.getGroupById).toBeCalledWith(validGroupId);
+          expect(response.status).toBe(200);
+        });
+        test('should respond with group data', async () => {
+          mockGroupService.getGroupById.mockReturnValueOnce(validGroupData);
+          const response = await request(application)
+            .get(`/group/${validGroupId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockGroupService.getGroupById).toBeCalledWith(validGroupId);
+          expect(response.body.group).toEqual(validGroupData);
+        });
+      });
+    });
+
+    describe('GET /groups (get groups)', () => {
+      beforeEach(() => {
+        mockGroupService.getGroups.mockClear();
+      });
+      describe('when jwt not valid', () => {
+        test('should respond with 401', async () => {
+          const response = await request(application)
+            .get(`/groups`)
+            .set('jwt-access-token', notValidJWT);
+          expect(response.status).toBe(401);
+        });
+      });
+      describe('when no jwt', () => {
+        test('should respond with 403 ', async () => {
+          const response = await request(application).get(`/groups`);
+          expect(response.status).toBe(403);
+        });
+      });
+      describe('when groups found', () => {
+        test('should respond with 200', async () => {
+          mockGroupService.getGroups.mockReturnValueOnce(validGroupData);
+          const response = await request(application)
+            .get(`/groups`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockGroupService.getGroups).toBeCalledWith();
+          expect(response.status).toBe(200);
+        });
+        test('should respond with data', async () => {
+          mockGroupService.getGroups.mockReturnValueOnce(validGroupData);
+          const response = await request(application)
+            .get(`/groups`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockGroupService.getGroups).toBeCalledWith();
+          expect(response.body.groups).toEqual(validGroupData);
+        });
+      });
+      describe('when groups not found', () => {
+        test('should respond with 404', async () => {
+          mockGroupService.getGroups.mockImplementationOnce(() => {
+            throw new FindGroupError('no group');
+          });
+          const response = await request(application)
+            .get(`/groups`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockGroupService.getGroups).toBeCalledWith();
+          expect(response.status).toBe(404);
+        });
+      });
+    });
+
+    describe('PUT /group/:id (update group)', () => {
+      beforeEach(() => {
+        mockGroupService.updateGroup.mockClear();
+      });
+      describe('when jwt not valid', () => {
+        test('should respond with 401', async () => {
+          const response = await request(application)
+            .put(`/group/${validGroupId}`)
+            .set('jwt-access-token', notValidJWT)
+            .send(validGroupData);
+          expect(response.status).toBe(401);
+        });
+      });
+      describe('when no jwt', () => {
+        test('should respond with 403 ', async () => {
+          const response = await request(application)
+            .put(`/group/${validGroupId}`)
+            .send(validGroupData);
+          expect(response.status).toBe(403);
+        });
+      });
+      describe('when group id not valid', () => {
+        test('should respond with 400', async () => {
+          const response = await request(application)
+            .put(`/group/${notValidGroupId}`)
+            .set('jwt-access-token', await getValidJWT())
+            .send(validGroupData);
+          expect(mockGroupService.updateGroup).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when group update data not valid', () => {
+        test('should respond with 400', async () => {
+          const response = await request(application)
+            .put(`/group/${validGroupId}`)
+            .set('jwt-access-token', await getValidJWT())
+            .send({ ...validGroupData, name: notValidGroupName });
+          expect(mockGroupService.updateGroup).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when group not found', () => {
+        test('should respond with 404', async () => {
+          mockGroupService.updateGroup.mockImplementationOnce(() => {
+            throw new FindGroupError('no group');
+          });
+          const response = await request(application)
+            .put(`/group/${validGroupId}`)
+            .set('jwt-access-token', await getValidJWT())
+            .send(validGroupData);
+          expect(mockGroupService.updateGroup).toBeCalledWith(
+            validGroupId,
+            validGroupData
+          );
+          expect(response.status).toBe(404);
+        });
+      });
+      describe('when group found', () => {
+        test('should respond with 200', async () => {
+          mockGroupService.updateGroup.mockReturnValueOnce(validGroupData);
+          const response = await request(application)
+            .put(`/group/${validGroupId}`)
+            .set('jwt-access-token', await getValidJWT())
+            .send(validGroupData);
+          expect(mockGroupService.updateGroup).toBeCalledWith(
+            validGroupId,
+            validGroupData
+          );
+          expect(response.status).toBe(200);
+        });
+        test('should respond with group data', async () => {
+          mockGroupService.updateGroup.mockReturnValueOnce(validGroupData);
+          const response = await request(application)
+            .put(`/group/${validGroupId}`)
+            .set('jwt-access-token', await getValidJWT())
+            .send(validGroupData);
+          expect(mockGroupService.updateGroup).toBeCalledWith(
+            validGroupId,
+            validGroupData
+          );
+          expect(response.body.updatedGroup).toEqual(validGroupData);
+        });
+      });
+    });
+
+    describe('DELETE /group/:id (delete group)', () => {
+      beforeEach(() => {
+        mockGroupService.deleteGroup.mockClear();
+      });
+      describe('when jwt not valid', () => {
+        test('should respond with 401', async () => {
+          const response = await request(application)
+            .delete(`/group/${validGroupId}`)
+            .set('jwt-access-token', notValidJWT);
+          expect(response.status).toBe(401);
+        });
+      });
+      describe('when no jwt', () => {
+        test('should respond with 403 ', async () => {
+          const response = await request(application).delete(
+            `/group/${validGroupId}`
+          );
+          expect(response.status).toBe(403);
+        });
+      });
+      describe('when group id not valid', () => {
+        test('should respond with 400', async () => {
+          const response = await request(application)
+            .delete(`/group/${notValidGroupId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockGroupService.deleteGroup).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when group not found', () => {
+        test('should respond with 404', async () => {
+          mockGroupService.deleteGroup.mockImplementationOnce(() => {
+            throw new FindGroupError('no group');
+          });
+          const response = await request(application)
+            .delete(`/group/${validGroupId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockGroupService.deleteGroup).toBeCalledWith(validGroupId);
+          expect(response.status).toBe(404);
+        });
+      });
+      describe('when group found', () => {
+        test('should respond with 200', async () => {
+          mockGroupService.deleteGroup.mockReturnValueOnce(validGroupData);
+          const response = await request(application)
+            .delete(`/group/${validGroupId}`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockGroupService.deleteGroup).toBeCalledWith(validGroupId);
+          expect(response.status).toBe(200);
+        });
+      });
+    });
+
+    describe('POST /group/:id/addusers add users to group)', () => {
+      beforeEach(() => {
+        mockGroupService.addUsersToGroup.mockClear();
+      });
+      describe('when jwt not valid', () => {
+        test('should respond with 401', async () => {
+          const response = await request(application)
+            .post(`/group/${validGroupId}/addusers`)
+            .set('jwt-access-token', notValidJWT);
+          expect(response.status).toBe(401);
+        });
+      });
+      describe('when no jwt', () => {
+        test('should respond with 403 ', async () => {
+          const response = await request(application).post(
+            `/group/${validGroupId}/addusers`
+          );
+          expect(response.status).toBe(403);
+        });
+      });
+      describe('when group id not valid', () => {
+        test('should respond with 400', async () => {
+          const response = await request(application)
+            .post(`/group/${notValidGroupId}/addusers`)
+            .set('jwt-access-token', await getValidJWT());
+          expect(mockGroupService.addUsersToGroup).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when user ids not valid', () => {
+        test('should respond with 400', async () => {
+          const response = await request(application)
+            .post(`/group/${validGroupId}/addusers`)
+            .set('jwt-access-token', await getValidJWT())
+            .send({usersId: notValidUserIds});
+          expect(mockGroupService.addUsersToGroup).not.toBeCalled();
+          expect(response.status).toBe(400);
+        });
+      });
+      describe('when request valid', () => {
+        test('should respond with 200', async () => {
+          mockGroupService.addUsersToGroup.mockReturnValueOnce(validGroupData);
+          const response = await request(application)
+            .post(`/group/${validGroupId}/addusers`)
+            .set('jwt-access-token', await getValidJWT())
+            .send({usersId: validUserIds});
+          expect(mockGroupService.addUsersToGroup).toBeCalledWith(
+            validGroupId,
+            validUserIds
+          );
+          expect(response.status).toBe(200);
+        });
+      });
+    });
+  });
+});

--- a/tests/controller.test.ts
+++ b/tests/controller.test.ts
@@ -67,7 +67,21 @@ const validSubstring = 'log';
 const notValidSubstring = 'logaaaaaaaaaaa';
 const validLimit = 3;
 const notValidLimit = 'a';
-
+const loginValidationErrorMessage =
+  'Error validating request body. "login" length must be at least 3 characters long.';
+const notValidCredentialsMessage = 'Bad Username/Password combination';
+const notValidJWTMessage = 'Failed jwt token';
+const noJWTMessage = 'No jwt token provided'
+const notValidUserIDMessage = 'Error validating request params. "id" length must be at least 36 characters long.'
+const notValidGroupIDMessage = 'Error validating request params. "id" length must be at least 36 characters long.'
+const successfullDeleteMessage = `group with id ${validGroupId} deleted`
+const noUserMessage  = 'no user'
+const noGroupMessage  = 'no group'
+const notValidLimitMessage  = 'Error validating request query. "limit" must be a number.'
+const notValidSubstringMessage = 'Error validating request query. "loginsubstring" length must be less than or equal to 10 characters long.'
+const notValidGroupNameMessage = 'Error validating request body. "name" length must be at least 3 characters long.'
+const notValidUsersMessage = 'Error validating request body. "usersId[0]" length must be at least 36 characters long. "usersId[1]" length must be at least 36 characters long.'
+const createdGroupRelationsName = 'grpup1'
 const validGroupData = {
   name: validGroupName,
   permissions: validGroupPermissions,
@@ -83,13 +97,9 @@ async function getValidJWT() {
   return response.body.token;
 }
 
-const application = createApplication(
-  mockUserService,
-  mockGroupService
-);
+const application = createApplication(mockUserService, mockGroupService);
 
 describe('CONTROLLER: ', () => {
-
   describe('User Controller: ', () => {
     describe('POST /user/login', () => {
       beforeEach(() => {
@@ -116,6 +126,7 @@ describe('CONTROLLER: ', () => {
             .send(body);
           expect(mockUserService.getUserByCredentials).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(loginValidationErrorMessage);
         });
       });
       describe('when user not found by credentials', () => {
@@ -127,6 +138,7 @@ describe('CONTROLLER: ', () => {
             .post('/user/login')
             .send(body);
           expect(response.status).toBe(401);
+          expect(response.text).toBe(notValidCredentialsMessage);
         });
       });
       describe('when user found by credentials', () => {
@@ -161,6 +173,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', notValidJWT)
             .send(body);
           expect(response.status).toBe(401);
+          expect(response.text).toBe(notValidJWTMessage)
         });
       });
       describe('when no jwt', () => {
@@ -168,6 +181,7 @@ describe('CONTROLLER: ', () => {
           const body = validUserData;
           const response = await request(application).post('/user').send(body);
           expect(response.status).toBe(403);
+          expect(response.text).toBe(noJWTMessage)
         });
       });
       describe('when user data valid', () => {
@@ -209,6 +223,7 @@ describe('CONTROLLER: ', () => {
             .send(body);
           expect(mockUserService.createUser).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(loginValidationErrorMessage)
         });
       });
     });
@@ -223,6 +238,7 @@ describe('CONTROLLER: ', () => {
             .get(`/user/${validUserId}`)
             .set('jwt-access-token', notValidJWT);
           expect(response.status).toBe(401);
+          expect(response.text).toBe(notValidJWTMessage)
         });
       });
       describe('when no jwt', () => {
@@ -231,6 +247,7 @@ describe('CONTROLLER: ', () => {
             `/user/${validUserId}`
           );
           expect(response.status).toBe(403);
+          expect(response.text).toBe(noJWTMessage)
         });
       });
       describe('when user id not valid', () => {
@@ -240,6 +257,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockUserService.getUserById).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(notValidUserIDMessage)
         });
       });
       describe('when user not found', () => {
@@ -252,6 +270,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockUserService.getUserById).toBeCalledWith(validUserId);
           expect(response.status).toBe(404);
+          expect(response.text).toBe(noUserMessage)
         });
       });
       describe('when user found', () => {
@@ -285,6 +304,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', notValidJWT)
             .send(validUserData);
           expect(response.status).toBe(401);
+          expect(response.text).toBe(notValidJWTMessage)
         });
       });
       describe('when no jwt', () => {
@@ -293,6 +313,7 @@ describe('CONTROLLER: ', () => {
             .put(`/user/${validUserId}`)
             .send(validUserData);
           expect(response.status).toBe(403);
+          expect(response.text).toBe(noJWTMessage)
         });
       });
       describe('when user id not valid', () => {
@@ -303,6 +324,7 @@ describe('CONTROLLER: ', () => {
             .send(validUserData);
           expect(mockUserService.updateUser).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(notValidUserIDMessage)
         });
       });
       describe('when user update data not valid', () => {
@@ -313,6 +335,7 @@ describe('CONTROLLER: ', () => {
             .send({ ...validUserData, login: notValidLogin });
           expect(mockUserService.updateUser).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(loginValidationErrorMessage)
         });
       });
       describe('when user not found', () => {
@@ -329,6 +352,7 @@ describe('CONTROLLER: ', () => {
             validUserData
           );
           expect(response.status).toBe(404);
+          expect(response.text).toBe(noUserMessage)
         });
       });
       describe('when user found', () => {
@@ -369,6 +393,7 @@ describe('CONTROLLER: ', () => {
             .delete(`/user/${validUserId}`)
             .set('jwt-access-token', notValidJWT);
           expect(response.status).toBe(401);
+          expect(response.text).toBe(notValidJWTMessage)
         });
       });
       describe('when no jwt', () => {
@@ -377,6 +402,7 @@ describe('CONTROLLER: ', () => {
             `/user/${validUserId}`
           );
           expect(response.status).toBe(403);
+          expect(response.text).toBe(noJWTMessage)
         });
       });
       describe('when user id not valid', () => {
@@ -386,6 +412,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockUserService.deleteUser).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(notValidUserIDMessage)
         });
       });
       describe('when user not found', () => {
@@ -398,6 +425,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockUserService.deleteUser).toBeCalledWith(validUserId);
           expect(response.status).toBe(404);
+          expect(response.text).toBe(noUserMessage)
         });
       });
       describe('when user found', () => {
@@ -432,12 +460,14 @@ describe('CONTROLLER: ', () => {
             .get(`/users`)
             .set('jwt-access-token', notValidJWT);
           expect(response.status).toBe(401);
+          expect(response.text).toBe(notValidJWTMessage)
         });
       });
       describe('when no jwt', () => {
         test('should respond with 403 ', async () => {
           const response = await request(application).get(`/users`);
           expect(response.status).toBe(403);
+          expect(response.text).toBe(noJWTMessage)
         });
       });
       describe('when limit param not valid', () => {
@@ -447,6 +477,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockUserService.getUsers).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(notValidLimitMessage)
         });
       });
       describe('when loginsubstring param not valid', () => {
@@ -456,6 +487,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockUserService.getUsers).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(notValidSubstringMessage)
         });
       });
       describe('when request valid', () => {
@@ -498,6 +530,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', notValidJWT)
             .send(body);
           expect(response.status).toBe(401);
+          expect(response.text).toBe(notValidJWTMessage)
         });
       });
       describe('when no jwt', () => {
@@ -505,6 +538,7 @@ describe('CONTROLLER: ', () => {
           const body = validGroupData;
           const response = await request(application).post('/group').send(body);
           expect(response.status).toBe(403);
+          expect(response.text).toBe(noJWTMessage)
         });
       });
       describe('when group data valid', () => {
@@ -546,6 +580,7 @@ describe('CONTROLLER: ', () => {
             .send(body);
           expect(mockGroupService.createGroup).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(notValidGroupNameMessage)
         });
       });
     });
@@ -560,6 +595,7 @@ describe('CONTROLLER: ', () => {
             .get(`/group/${validGroupId}`)
             .set('jwt-access-token', notValidJWT);
           expect(response.status).toBe(401);
+          expect(response.text).toBe(notValidJWTMessage)
         });
       });
       describe('when no jwt', () => {
@@ -568,6 +604,7 @@ describe('CONTROLLER: ', () => {
             `/group/${validGroupId}`
           );
           expect(response.status).toBe(403);
+          expect(response.text).toBe(noJWTMessage)
         });
       });
       describe('when group id not valid', () => {
@@ -577,6 +614,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockGroupService.getGroupById).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(notValidGroupIDMessage)
         });
       });
       describe('when group not found', () => {
@@ -589,6 +627,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockGroupService.getGroupById).toBeCalledWith(validGroupId);
           expect(response.status).toBe(404);
+          expect(response.text).toBe(noGroupMessage)
         });
       });
       describe('when group found', () => {
@@ -621,12 +660,14 @@ describe('CONTROLLER: ', () => {
             .get(`/groups`)
             .set('jwt-access-token', notValidJWT);
           expect(response.status).toBe(401);
+          expect(response.text).toBe(notValidJWTMessage)
         });
       });
       describe('when no jwt', () => {
         test('should respond with 403 ', async () => {
           const response = await request(application).get(`/groups`);
           expect(response.status).toBe(403);
+          expect(response.text).toBe(noJWTMessage)
         });
       });
       describe('when groups found', () => {
@@ -657,6 +698,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockGroupService.getGroups).toBeCalledWith();
           expect(response.status).toBe(404);
+          expect(response.text).toBe(noGroupMessage)
         });
       });
     });
@@ -672,6 +714,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', notValidJWT)
             .send(validGroupData);
           expect(response.status).toBe(401);
+          expect(response.text).toBe(notValidJWTMessage)
         });
       });
       describe('when no jwt', () => {
@@ -680,6 +723,7 @@ describe('CONTROLLER: ', () => {
             .put(`/group/${validGroupId}`)
             .send(validGroupData);
           expect(response.status).toBe(403);
+          expect(response.text).toBe(noJWTMessage)
         });
       });
       describe('when group id not valid', () => {
@@ -690,6 +734,7 @@ describe('CONTROLLER: ', () => {
             .send(validGroupData);
           expect(mockGroupService.updateGroup).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(notValidGroupIDMessage)
         });
       });
       describe('when group update data not valid', () => {
@@ -700,6 +745,7 @@ describe('CONTROLLER: ', () => {
             .send({ ...validGroupData, name: notValidGroupName });
           expect(mockGroupService.updateGroup).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(notValidGroupNameMessage)
         });
       });
       describe('when group not found', () => {
@@ -716,6 +762,7 @@ describe('CONTROLLER: ', () => {
             validGroupData
           );
           expect(response.status).toBe(404);
+          expect(response.text).toBe(noGroupMessage)
         });
       });
       describe('when group found', () => {
@@ -756,6 +803,7 @@ describe('CONTROLLER: ', () => {
             .delete(`/group/${validGroupId}`)
             .set('jwt-access-token', notValidJWT);
           expect(response.status).toBe(401);
+          expect(response.text).toBe(notValidJWTMessage)
         });
       });
       describe('when no jwt', () => {
@@ -764,6 +812,7 @@ describe('CONTROLLER: ', () => {
             `/group/${validGroupId}`
           );
           expect(response.status).toBe(403);
+          expect(response.text).toBe(noJWTMessage)
         });
       });
       describe('when group id not valid', () => {
@@ -773,6 +822,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockGroupService.deleteGroup).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(notValidGroupIDMessage)
         });
       });
       describe('when group not found', () => {
@@ -785,6 +835,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockGroupService.deleteGroup).toBeCalledWith(validGroupId);
           expect(response.status).toBe(404);
+          expect(response.text).toBe(noGroupMessage)
         });
       });
       describe('when group found', () => {
@@ -795,6 +846,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockGroupService.deleteGroup).toBeCalledWith(validGroupId);
           expect(response.status).toBe(200);
+          expect(response.body.message).toBe(successfullDeleteMessage)
         });
       });
     });
@@ -809,6 +861,7 @@ describe('CONTROLLER: ', () => {
             .post(`/group/${validGroupId}/addusers`)
             .set('jwt-access-token', notValidJWT);
           expect(response.status).toBe(401);
+          expect(response.text).toBe(notValidJWTMessage)
         });
       });
       describe('when no jwt', () => {
@@ -817,6 +870,7 @@ describe('CONTROLLER: ', () => {
             `/group/${validGroupId}/addusers`
           );
           expect(response.status).toBe(403);
+          expect(response.text).toBe(noJWTMessage)
         });
       });
       describe('when group id not valid', () => {
@@ -826,6 +880,7 @@ describe('CONTROLLER: ', () => {
             .set('jwt-access-token', await getValidJWT());
           expect(mockGroupService.addUsersToGroup).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(notValidGroupIDMessage)
         });
       });
       describe('when user ids not valid', () => {
@@ -833,9 +888,10 @@ describe('CONTROLLER: ', () => {
           const response = await request(application)
             .post(`/group/${validGroupId}/addusers`)
             .set('jwt-access-token', await getValidJWT())
-            .send({usersId: notValidUserIds});
+            .send({ usersId: notValidUserIds });
           expect(mockGroupService.addUsersToGroup).not.toBeCalled();
           expect(response.status).toBe(400);
+          expect(response.text).toBe(notValidUsersMessage)
         });
       });
       describe('when request valid', () => {
@@ -844,12 +900,13 @@ describe('CONTROLLER: ', () => {
           const response = await request(application)
             .post(`/group/${validGroupId}/addusers`)
             .set('jwt-access-token', await getValidJWT())
-            .send({usersId: validUserIds});
+            .send({ usersId: validUserIds });
           expect(mockGroupService.addUsersToGroup).toBeCalledWith(
             validGroupId,
             validUserIds
           );
           expect(response.status).toBe(200);
+          expect(response.body.createdGroupRelations.name).toBe(createdGroupRelationsName)
         });
       });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "experimentalDecorators": true,
-    "strictPropertyInitialization": false
+    "strictPropertyInitialization": false,
+    "target": "ES2022"
   },
   "exclude": ["node_modules"],
   "emitDecoratorMetadata": true,


### PR DESCRIPTION
TASK 7.1
• Add unit tests for User entity controller methods using Jest library (https://jestjs.io/).
• Add unit tests for Group entity controller methods using Jest.
TASK 7.2
The information on DB connection (connection string) should be stored in .env file and should be
passed to the application using environment variables with the help of dotenv package
(https://www.npmjs.com/package/dotenv).
As an alternative package you can also use config (https://www.npmjs.com/package/config).
EVALUATION CRITERIA
2. Jest is installed. Some unit tests for controllers are added.
3. Task 7.1 is implemented partially; unit tests are added only for a single entity controller.
4. Task 7.1 is fulfilled to the full extent.
5. Task 7.2 is fulfilled to the full extent.
5*. Add integration tests for getUsers and createUser methods with mock sequalize.